### PR TITLE
Save as model.bim too when working with folder serialized models

### DIFF
--- a/TOMWrapper/TOMWrapper/Serialization/SerializeOptions.cs
+++ b/TOMWrapper/TOMWrapper/Serialization/SerializeOptions.cs
@@ -64,8 +64,9 @@ namespace TabularEditor.TOMWrapper.Serialization
         public bool IgnoreTimestamps = true;
         public bool IgnoreLineageTags { get; set; } = false;
         public bool ShouldSerializeIgnoreLineageTags() => IgnoreLineageTags;
-        public bool SplitMultilineStrings = true;
+        public bool SplitMultilineStrings = true;        
         public bool PrefixFilenames = false;
+        public bool AlsoSaveAsBim = false;
         public bool LocalTranslations = false;
         public bool LocalPerspectives = false;
         public bool LocalRelationships = false;
@@ -88,6 +89,7 @@ namespace TabularEditor.TOMWrapper.Serialization
                 && other.IgnoreTimestamps == IgnoreTimestamps
                 && other.SplitMultilineStrings == SplitMultilineStrings
                 && other.PrefixFilenames == PrefixFilenames
+                && other.AlsoSaveAsBim == AlsoSaveAsBim
                 && other.LocalTranslations == LocalTranslations
                 && other.LocalPerspectives == LocalPerspectives
                 && other.LocalRelationships == LocalRelationships;

--- a/TOMWrapper/TOMWrapper/Serialization/SerializeOptions.cs
+++ b/TOMWrapper/TOMWrapper/Serialization/SerializeOptions.cs
@@ -64,7 +64,7 @@ namespace TabularEditor.TOMWrapper.Serialization
         public bool IgnoreTimestamps = true;
         public bool IgnoreLineageTags { get; set; } = false;
         public bool ShouldSerializeIgnoreLineageTags() => IgnoreLineageTags;
-        public bool SplitMultilineStrings = true;        
+        public bool SplitMultilineStrings = true;
         public bool PrefixFilenames = false;
         public bool AlsoSaveAsBim = false;
         public bool LocalTranslations = false;

--- a/TabularEditor.sln
+++ b/TabularEditor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2050
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31515.178
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TabularEditor", "TabularEditor\TabularEditor.csproj", "{F7588159-3F24-4BFA-A6F6-551657896C34}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -26,8 +26,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		SharedAssemblyInfo.cs = SharedAssemblyInfo.cs
 	EndProjectSection
-EndProject
-Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "TabularEditorInstaller", "TabularEditorInstaller\TabularEditorInstaller.vdproj", "{3CF53981-9965-436B-9805-D6F844C2CE15}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TOMWrapperTest", "TOMWrapperTest\TOMWrapperTest.csproj", "{546659EE-5DA6-4BAC-BD5E-0D898389201A}"
 EndProject
@@ -61,8 +59,6 @@ Global
 		{28244C9C-E8CE-43DF-AB98-500BEE2C03A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{28244C9C-E8CE-43DF-AB98-500BEE2C03A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{28244C9C-E8CE-43DF-AB98-500BEE2C03A1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3CF53981-9965-436B-9805-D6F844C2CE15}.Debug|Any CPU.ActiveCfg = Debug
-		{3CF53981-9965-436B-9805-D6F844C2CE15}.Release|Any CPU.ActiveCfg = Release
 		{546659EE-5DA6-4BAC-BD5E-0D898389201A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{546659EE-5DA6-4BAC-BD5E-0D898389201A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{546659EE-5DA6-4BAC-BD5E-0D898389201A}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/TabularEditor.sln
+++ b/TabularEditor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31515.178
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2050
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TabularEditor", "TabularEditor\TabularEditor.csproj", "{F7588159-3F24-4BFA-A6F6-551657896C34}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -26,6 +26,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		SharedAssemblyInfo.cs = SharedAssemblyInfo.cs
 	EndProjectSection
+EndProject
+Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "TabularEditorInstaller", "TabularEditorInstaller\TabularEditorInstaller.vdproj", "{3CF53981-9965-436B-9805-D6F844C2CE15}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TOMWrapperTest", "TOMWrapperTest\TOMWrapperTest.csproj", "{546659EE-5DA6-4BAC-BD5E-0D898389201A}"
 EndProject
@@ -59,6 +61,8 @@ Global
 		{28244C9C-E8CE-43DF-AB98-500BEE2C03A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{28244C9C-E8CE-43DF-AB98-500BEE2C03A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{28244C9C-E8CE-43DF-AB98-500BEE2C03A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CF53981-9965-436B-9805-D6F844C2CE15}.Debug|Any CPU.ActiveCfg = Debug
+		{3CF53981-9965-436B-9805-D6F844C2CE15}.Release|Any CPU.ActiveCfg = Release
 		{546659EE-5DA6-4BAC-BD5E-0D898389201A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{546659EE-5DA6-4BAC-BD5E-0D898389201A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{546659EE-5DA6-4BAC-BD5E-0D898389201A}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/TabularEditor/UI/Dialogs/PreferencesForm.Designer.cs
+++ b/TabularEditor/UI/Dialogs/PreferencesForm.Designer.cs
@@ -96,6 +96,8 @@
             this.cmbSeparators = new System.Windows.Forms.ComboBox();
             this.chkBackgroundBpa = new System.Windows.Forms.CheckBox();
             this.chkAnnotateDeploymentMetadata = new System.Windows.Forms.CheckBox();
+            this.chkIgnoreLineageTags = new System.Windows.Forms.CheckBox();
+            this.chkIgnoreLineageTagsCM = new System.Windows.Forms.CheckBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabFeatures = new System.Windows.Forms.TabPage();
@@ -129,16 +131,16 @@
             this.groupBox5 = new System.Windows.Forms.GroupBox();
             this.tabSerialization = new System.Windows.Forms.TabPage();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.chkAlsoSaveAsBim = new System.Windows.Forms.CheckBox();
             this.treeView1 = new System.Windows.Forms.TreeView();
             this.label1 = new System.Windows.Forms.Label();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.tabCurrentModel = new System.Windows.Forms.TabPage();
             this.grpSaveToFolder = new System.Windows.Forms.GroupBox();
+            this.chkAlsoSaveAsBimCM = new System.Windows.Forms.CheckBox();
             this.treeView2 = new System.Windows.Forms.TreeView();
             this.label2 = new System.Windows.Forms.Label();
             this.groupBox8 = new System.Windows.Forms.GroupBox();
-            this.chkIgnoreLineageTags = new System.Windows.Forms.CheckBox();
-            this.chkIgnoreLineageTagsCM = new System.Windows.Forms.CheckBox();
             this.groupBox3.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.tabFeatures.SuspendLayout();
@@ -163,9 +165,10 @@
             // 
             this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btnOK.Location = new System.Drawing.Point(233, 407);
+            this.btnOK.Location = new System.Drawing.Point(311, 501);
+            this.btnOK.Margin = new System.Windows.Forms.Padding(4);
             this.btnOK.Name = "btnOK";
-            this.btnOK.Size = new System.Drawing.Size(75, 23);
+            this.btnOK.Size = new System.Drawing.Size(100, 28);
             this.btnOK.TabIndex = 1;
             this.btnOK.Text = "OK";
             this.btnOK.UseVisualStyleBackColor = true;
@@ -174,9 +177,10 @@
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(314, 407);
+            this.btnCancel.Location = new System.Drawing.Point(419, 501);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(4);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.Size = new System.Drawing.Size(100, 28);
             this.btnCancel.TabIndex = 2;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
@@ -184,9 +188,10 @@
             // chkFixup
             // 
             this.chkFixup.AutoSize = true;
-            this.chkFixup.Location = new System.Drawing.Point(6, 19);
+            this.chkFixup.Location = new System.Drawing.Point(8, 23);
+            this.chkFixup.Margin = new System.Windows.Forms.Padding(4);
             this.chkFixup.Name = "chkFixup";
-            this.chkFixup.Size = new System.Drawing.Size(138, 17);
+            this.chkFixup.Size = new System.Drawing.Size(181, 21);
             this.chkFixup.TabIndex = 1;
             this.chkFixup.Text = "Automatic formula fix-up";
             this.toolTip1.SetToolTip(this.chkFixup, "When this is checked, expressions of Measures, Calculated Columns and Calculated " +
@@ -196,9 +201,10 @@
             // chkIgnoreTimestamps
             // 
             this.chkIgnoreTimestamps.AutoSize = true;
-            this.chkIgnoreTimestamps.Location = new System.Drawing.Point(6, 42);
+            this.chkIgnoreTimestamps.Location = new System.Drawing.Point(8, 52);
+            this.chkIgnoreTimestamps.Margin = new System.Windows.Forms.Padding(4);
             this.chkIgnoreTimestamps.Name = "chkIgnoreTimestamps";
-            this.chkIgnoreTimestamps.Size = new System.Drawing.Size(111, 17);
+            this.chkIgnoreTimestamps.Size = new System.Drawing.Size(145, 21);
             this.chkIgnoreTimestamps.TabIndex = 0;
             this.chkIgnoreTimestamps.Text = "Ignore timestamps";
             this.toolTip1.SetToolTip(this.chkIgnoreTimestamps, "If checked, editing timestamps are not serialized into the .json files");
@@ -207,9 +213,10 @@
             // chkIgnoreInfObjects
             // 
             this.chkIgnoreInfObjects.AutoSize = true;
-            this.chkIgnoreInfObjects.Location = new System.Drawing.Point(6, 19);
+            this.chkIgnoreInfObjects.Location = new System.Drawing.Point(8, 23);
+            this.chkIgnoreInfObjects.Margin = new System.Windows.Forms.Padding(4);
             this.chkIgnoreInfObjects.Name = "chkIgnoreInfObjects";
-            this.chkIgnoreInfObjects.Size = new System.Drawing.Size(131, 17);
+            this.chkIgnoreInfObjects.Size = new System.Drawing.Size(172, 21);
             this.chkIgnoreInfObjects.TabIndex = 1;
             this.chkIgnoreInfObjects.Text = "Ignore inferred objects";
             this.toolTip1.SetToolTip(this.chkIgnoreInfObjects, "If checked, objects whose lifetime is controlled by the server (RowNumber, attrib" +
@@ -219,9 +226,10 @@
             // chkIgnoreInfProps
             // 
             this.chkIgnoreInfProps.AutoSize = true;
-            this.chkIgnoreInfProps.Location = new System.Drawing.Point(143, 19);
+            this.chkIgnoreInfProps.Location = new System.Drawing.Point(191, 23);
+            this.chkIgnoreInfProps.Margin = new System.Windows.Forms.Padding(4);
             this.chkIgnoreInfProps.Name = "chkIgnoreInfProps";
-            this.chkIgnoreInfProps.Size = new System.Drawing.Size(143, 17);
+            this.chkIgnoreInfProps.Size = new System.Drawing.Size(191, 21);
             this.chkIgnoreInfProps.TabIndex = 2;
             this.chkIgnoreInfProps.Text = "Ignore inferred properties";
             this.toolTip1.SetToolTip(this.chkIgnoreInfProps, "If checked, objects whose value is controlled by the server (Column.State, etc.) " +
@@ -231,9 +239,10 @@
             // chkSplitMultiline
             // 
             this.chkSplitMultiline.AutoSize = true;
-            this.chkSplitMultiline.Location = new System.Drawing.Point(143, 42);
+            this.chkSplitMultiline.Location = new System.Drawing.Point(191, 52);
+            this.chkSplitMultiline.Margin = new System.Windows.Forms.Padding(4);
             this.chkSplitMultiline.Name = "chkSplitMultiline";
-            this.chkSplitMultiline.Size = new System.Drawing.Size(114, 17);
+            this.chkSplitMultiline.Size = new System.Drawing.Size(151, 21);
             this.chkSplitMultiline.TabIndex = 3;
             this.chkSplitMultiline.Text = "Split multiline string";
             this.toolTip1.SetToolTip(this.chkSplitMultiline, "If checked, expressions and other multiline string properties are serialized as a" +
@@ -244,9 +253,10 @@
             // 
             this.chkLocalTranslations.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.chkLocalTranslations.AutoSize = true;
-            this.chkLocalTranslations.Location = new System.Drawing.Point(6, 217);
+            this.chkLocalTranslations.Location = new System.Drawing.Point(8, 267);
+            this.chkLocalTranslations.Margin = new System.Windows.Forms.Padding(4);
             this.chkLocalTranslations.Name = "chkLocalTranslations";
-            this.chkLocalTranslations.Size = new System.Drawing.Size(171, 17);
+            this.chkLocalTranslations.Size = new System.Drawing.Size(229, 21);
             this.chkLocalTranslations.TabIndex = 8;
             this.chkLocalTranslations.Text = "Serialize translations per-object";
             this.toolTip1.SetToolTip(this.chkLocalTranslations, "If checked, all translatable objects (measures, columns, etc.) will have their tr" +
@@ -258,9 +268,10 @@
             // 
             this.chkLocalPerspectives.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.chkLocalPerspectives.AutoSize = true;
-            this.chkLocalPerspectives.Location = new System.Drawing.Point(6, 194);
+            this.chkLocalPerspectives.Location = new System.Drawing.Point(8, 239);
+            this.chkLocalPerspectives.Margin = new System.Windows.Forms.Padding(4);
             this.chkLocalPerspectives.Name = "chkLocalPerspectives";
-            this.chkLocalPerspectives.Size = new System.Drawing.Size(227, 17);
+            this.chkLocalPerspectives.Size = new System.Drawing.Size(303, 21);
             this.chkLocalPerspectives.TabIndex = 7;
             this.chkLocalPerspectives.Text = "Serialize perspective information per-object";
             this.toolTip1.SetToolTip(this.chkLocalPerspectives, "If checked, all objects that can be toggled in a perspective, will have their per" +
@@ -273,9 +284,10 @@
             // 
             this.chkLocalRelationships.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.chkLocalRelationships.AutoSize = true;
-            this.chkLocalRelationships.Location = new System.Drawing.Point(6, 240);
+            this.chkLocalRelationships.Location = new System.Drawing.Point(8, 295);
+            this.chkLocalRelationships.Margin = new System.Windows.Forms.Padding(4);
             this.chkLocalRelationships.Name = "chkLocalRelationships";
-            this.chkLocalRelationships.Size = new System.Drawing.Size(231, 17);
+            this.chkLocalRelationships.Size = new System.Drawing.Size(312, 21);
             this.chkLocalRelationships.TabIndex = 9;
             this.chkLocalRelationships.Text = "Serialize relationships by their starting tables";
             this.toolTip1.SetToolTip(this.chkLocalRelationships, "If checked, all relationships will be stored as a separate file on the \"From\" sid" +
@@ -286,9 +298,10 @@
             // chkAllowUnsupportedPBIFeatures
             // 
             this.chkAllowUnsupportedPBIFeatures.AutoSize = true;
-            this.chkAllowUnsupportedPBIFeatures.Location = new System.Drawing.Point(6, 21);
+            this.chkAllowUnsupportedPBIFeatures.Location = new System.Drawing.Point(8, 26);
+            this.chkAllowUnsupportedPBIFeatures.Margin = new System.Windows.Forms.Padding(4);
             this.chkAllowUnsupportedPBIFeatures.Name = "chkAllowUnsupportedPBIFeatures";
-            this.chkAllowUnsupportedPBIFeatures.Size = new System.Drawing.Size(268, 17);
+            this.chkAllowUnsupportedPBIFeatures.Size = new System.Drawing.Size(355, 21);
             this.chkAllowUnsupportedPBIFeatures.TabIndex = 0;
             this.chkAllowUnsupportedPBIFeatures.Text = "Allow unsupported Power BI features (experimental)";
             this.toolTip1.SetToolTip(this.chkAllowUnsupportedPBIFeatures, "Checking this, will let you edit all TOM objects and properties when connected to" +
@@ -298,9 +311,10 @@
             // chkChangeDetectionLocalServer
             // 
             this.chkChangeDetectionLocalServer.AutoSize = true;
-            this.chkChangeDetectionLocalServer.Location = new System.Drawing.Point(6, 67);
+            this.chkChangeDetectionLocalServer.Location = new System.Drawing.Point(8, 82);
+            this.chkChangeDetectionLocalServer.Margin = new System.Windows.Forms.Padding(4);
             this.chkChangeDetectionLocalServer.Name = "chkChangeDetectionLocalServer";
-            this.chkChangeDetectionLocalServer.Size = new System.Drawing.Size(270, 17);
+            this.chkChangeDetectionLocalServer.Size = new System.Drawing.Size(355, 21);
             this.chkChangeDetectionLocalServer.TabIndex = 0;
             this.chkChangeDetectionLocalServer.Text = "Detect changes on local AS instance (experimental)";
             this.toolTip1.SetToolTip(this.chkChangeDetectionLocalServer, resources.GetString("chkChangeDetectionLocalServer.ToolTip"));
@@ -309,9 +323,10 @@
             // chkCopyIncludeOLS
             // 
             this.chkCopyIncludeOLS.AutoSize = true;
-            this.chkCopyIncludeOLS.Location = new System.Drawing.Point(191, 42);
+            this.chkCopyIncludeOLS.Location = new System.Drawing.Point(255, 52);
+            this.chkCopyIncludeOLS.Margin = new System.Windows.Forms.Padding(4);
             this.chkCopyIncludeOLS.Name = "chkCopyIncludeOLS";
-            this.chkCopyIncludeOLS.Size = new System.Drawing.Size(157, 17);
+            this.chkCopyIncludeOLS.Size = new System.Drawing.Size(204, 21);
             this.chkCopyIncludeOLS.TabIndex = 3;
             this.chkCopyIncludeOLS.Text = "Include object-level security";
             this.toolTip1.SetToolTip(this.chkCopyIncludeOLS, "Include object-level security when copying tables, columns, hierarchies or measur" +
@@ -321,9 +336,10 @@
             // chkCopyIncludeRLS
             // 
             this.chkCopyIncludeRLS.AutoSize = true;
-            this.chkCopyIncludeRLS.Location = new System.Drawing.Point(191, 19);
+            this.chkCopyIncludeRLS.Location = new System.Drawing.Point(255, 23);
+            this.chkCopyIncludeRLS.Margin = new System.Windows.Forms.Padding(4);
             this.chkCopyIncludeRLS.Name = "chkCopyIncludeRLS";
-            this.chkCopyIncludeRLS.Size = new System.Drawing.Size(145, 17);
+            this.chkCopyIncludeRLS.Size = new System.Drawing.Size(188, 21);
             this.chkCopyIncludeRLS.TabIndex = 2;
             this.chkCopyIncludeRLS.Text = "Include row-level security";
             this.toolTip1.SetToolTip(this.chkCopyIncludeRLS, "Include row-level security when copying tables.");
@@ -332,9 +348,10 @@
             // chkCopyIncludePerspectives
             // 
             this.chkCopyIncludePerspectives.AutoSize = true;
-            this.chkCopyIncludePerspectives.Location = new System.Drawing.Point(6, 42);
+            this.chkCopyIncludePerspectives.Location = new System.Drawing.Point(8, 52);
+            this.chkCopyIncludePerspectives.Margin = new System.Windows.Forms.Padding(4);
             this.chkCopyIncludePerspectives.Name = "chkCopyIncludePerspectives";
-            this.chkCopyIncludePerspectives.Size = new System.Drawing.Size(178, 17);
+            this.chkCopyIncludePerspectives.Size = new System.Drawing.Size(233, 21);
             this.chkCopyIncludePerspectives.TabIndex = 1;
             this.chkCopyIncludePerspectives.Text = "Include perspective membership";
             this.toolTip1.SetToolTip(this.chkCopyIncludePerspectives, "Include perspective membership when copying objects that can be toggled in perspe" +
@@ -344,9 +361,10 @@
             // chkCopyIncludeTranslations
             // 
             this.chkCopyIncludeTranslations.AutoSize = true;
-            this.chkCopyIncludeTranslations.Location = new System.Drawing.Point(6, 19);
+            this.chkCopyIncludeTranslations.Location = new System.Drawing.Point(8, 23);
+            this.chkCopyIncludeTranslations.Margin = new System.Windows.Forms.Padding(4);
             this.chkCopyIncludeTranslations.Name = "chkCopyIncludeTranslations";
-            this.chkCopyIncludeTranslations.Size = new System.Drawing.Size(117, 17);
+            this.chkCopyIncludeTranslations.Size = new System.Drawing.Size(152, 21);
             this.chkCopyIncludeTranslations.TabIndex = 0;
             this.chkCopyIncludeTranslations.Text = "Include translations";
             this.toolTip1.SetToolTip(this.chkCopyIncludeTranslations, "Include translations when copying translatable objects");
@@ -355,9 +373,10 @@
             // chkAutoBackup
             // 
             this.chkAutoBackup.AutoSize = true;
-            this.chkAutoBackup.Location = new System.Drawing.Point(6, 44);
+            this.chkAutoBackup.Location = new System.Drawing.Point(8, 54);
+            this.chkAutoBackup.Margin = new System.Windows.Forms.Padding(4);
             this.chkAutoBackup.Name = "chkAutoBackup";
-            this.chkAutoBackup.Size = new System.Drawing.Size(168, 17);
+            this.chkAutoBackup.Size = new System.Drawing.Size(217, 21);
             this.chkAutoBackup.TabIndex = 6;
             this.chkAutoBackup.Text = "Save Model.bim backup here:";
             this.toolTip1.SetToolTip(this.chkAutoBackup, resources.GetString("chkAutoBackup.ToolTip"));
@@ -367,9 +386,10 @@
             // chkPrefixFiles
             // 
             this.chkPrefixFiles.AutoSize = true;
-            this.chkPrefixFiles.Location = new System.Drawing.Point(6, 19);
+            this.chkPrefixFiles.Location = new System.Drawing.Point(8, 23);
+            this.chkPrefixFiles.Margin = new System.Windows.Forms.Padding(4);
             this.chkPrefixFiles.Name = "chkPrefixFiles";
-            this.chkPrefixFiles.Size = new System.Drawing.Size(99, 17);
+            this.chkPrefixFiles.Size = new System.Drawing.Size(129, 21);
             this.chkPrefixFiles.TabIndex = 10;
             this.chkPrefixFiles.Text = "Prefix filenames";
             this.toolTip1.SetToolTip(this.chkPrefixFiles, "If checked, files and folders representing individual objects, will be prefixed b" +
@@ -379,9 +399,10 @@
             // chkPrefixFilesCM
             // 
             this.chkPrefixFilesCM.AutoSize = true;
-            this.chkPrefixFilesCM.Location = new System.Drawing.Point(6, 19);
+            this.chkPrefixFilesCM.Location = new System.Drawing.Point(8, 23);
+            this.chkPrefixFilesCM.Margin = new System.Windows.Forms.Padding(4);
             this.chkPrefixFilesCM.Name = "chkPrefixFilesCM";
-            this.chkPrefixFilesCM.Size = new System.Drawing.Size(99, 17);
+            this.chkPrefixFilesCM.Size = new System.Drawing.Size(129, 21);
             this.chkPrefixFilesCM.TabIndex = 10;
             this.chkPrefixFilesCM.Text = "Prefix filenames";
             this.toolTip1.SetToolTip(this.chkPrefixFilesCM, "If checked, files and folders representing individual objects, will be prefixed b" +
@@ -392,9 +413,10 @@
             // 
             this.chkLocalRelationshipsCM.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.chkLocalRelationshipsCM.AutoSize = true;
-            this.chkLocalRelationshipsCM.Location = new System.Drawing.Point(6, 240);
+            this.chkLocalRelationshipsCM.Location = new System.Drawing.Point(8, 295);
+            this.chkLocalRelationshipsCM.Margin = new System.Windows.Forms.Padding(4);
             this.chkLocalRelationshipsCM.Name = "chkLocalRelationshipsCM";
-            this.chkLocalRelationshipsCM.Size = new System.Drawing.Size(231, 17);
+            this.chkLocalRelationshipsCM.Size = new System.Drawing.Size(312, 21);
             this.chkLocalRelationshipsCM.TabIndex = 9;
             this.chkLocalRelationshipsCM.Text = "Serialize relationships by their starting tables";
             this.toolTip1.SetToolTip(this.chkLocalRelationshipsCM, "If checked, all relationships will be stored as a separate file on the \"From\" sid" +
@@ -406,9 +428,10 @@
             // 
             this.chkLocalTranslationsCM.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.chkLocalTranslationsCM.AutoSize = true;
-            this.chkLocalTranslationsCM.Location = new System.Drawing.Point(6, 217);
+            this.chkLocalTranslationsCM.Location = new System.Drawing.Point(8, 267);
+            this.chkLocalTranslationsCM.Margin = new System.Windows.Forms.Padding(4);
             this.chkLocalTranslationsCM.Name = "chkLocalTranslationsCM";
-            this.chkLocalTranslationsCM.Size = new System.Drawing.Size(171, 17);
+            this.chkLocalTranslationsCM.Size = new System.Drawing.Size(229, 21);
             this.chkLocalTranslationsCM.TabIndex = 8;
             this.chkLocalTranslationsCM.Text = "Serialize translations per-object";
             this.toolTip1.SetToolTip(this.chkLocalTranslationsCM, "If checked, all translatable objects (measures, columns, etc.) will have their tr" +
@@ -420,9 +443,10 @@
             // 
             this.chkLocalPerspectivesCM.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.chkLocalPerspectivesCM.AutoSize = true;
-            this.chkLocalPerspectivesCM.Location = new System.Drawing.Point(6, 194);
+            this.chkLocalPerspectivesCM.Location = new System.Drawing.Point(8, 239);
+            this.chkLocalPerspectivesCM.Margin = new System.Windows.Forms.Padding(4);
             this.chkLocalPerspectivesCM.Name = "chkLocalPerspectivesCM";
-            this.chkLocalPerspectivesCM.Size = new System.Drawing.Size(227, 17);
+            this.chkLocalPerspectivesCM.Size = new System.Drawing.Size(303, 21);
             this.chkLocalPerspectivesCM.TabIndex = 7;
             this.chkLocalPerspectivesCM.Text = "Serialize perspective information per-object";
             this.toolTip1.SetToolTip(this.chkLocalPerspectivesCM, "If checked, all objects that can be toggled in a perspective, will have their per" +
@@ -434,9 +458,10 @@
             // chkSplitMultilineCM
             // 
             this.chkSplitMultilineCM.AutoSize = true;
-            this.chkSplitMultilineCM.Location = new System.Drawing.Point(143, 42);
+            this.chkSplitMultilineCM.Location = new System.Drawing.Point(191, 52);
+            this.chkSplitMultilineCM.Margin = new System.Windows.Forms.Padding(4);
             this.chkSplitMultilineCM.Name = "chkSplitMultilineCM";
-            this.chkSplitMultilineCM.Size = new System.Drawing.Size(114, 17);
+            this.chkSplitMultilineCM.Size = new System.Drawing.Size(151, 21);
             this.chkSplitMultilineCM.TabIndex = 3;
             this.chkSplitMultilineCM.Text = "Split multiline string";
             this.toolTip1.SetToolTip(this.chkSplitMultilineCM, "If checked, expressions and other multiline string properties are serialized as a" +
@@ -446,9 +471,10 @@
             // chkIgnoreInfPropsCM
             // 
             this.chkIgnoreInfPropsCM.AutoSize = true;
-            this.chkIgnoreInfPropsCM.Location = new System.Drawing.Point(143, 19);
+            this.chkIgnoreInfPropsCM.Location = new System.Drawing.Point(191, 23);
+            this.chkIgnoreInfPropsCM.Margin = new System.Windows.Forms.Padding(4);
             this.chkIgnoreInfPropsCM.Name = "chkIgnoreInfPropsCM";
-            this.chkIgnoreInfPropsCM.Size = new System.Drawing.Size(143, 17);
+            this.chkIgnoreInfPropsCM.Size = new System.Drawing.Size(191, 21);
             this.chkIgnoreInfPropsCM.TabIndex = 2;
             this.chkIgnoreInfPropsCM.Text = "Ignore inferred properties";
             this.toolTip1.SetToolTip(this.chkIgnoreInfPropsCM, "If checked, objects whose value is controlled by the server (Column.State, etc.) " +
@@ -458,9 +484,10 @@
             // chkIgnoreInfObjectsCM
             // 
             this.chkIgnoreInfObjectsCM.AutoSize = true;
-            this.chkIgnoreInfObjectsCM.Location = new System.Drawing.Point(6, 19);
+            this.chkIgnoreInfObjectsCM.Location = new System.Drawing.Point(8, 23);
+            this.chkIgnoreInfObjectsCM.Margin = new System.Windows.Forms.Padding(4);
             this.chkIgnoreInfObjectsCM.Name = "chkIgnoreInfObjectsCM";
-            this.chkIgnoreInfObjectsCM.Size = new System.Drawing.Size(131, 17);
+            this.chkIgnoreInfObjectsCM.Size = new System.Drawing.Size(172, 21);
             this.chkIgnoreInfObjectsCM.TabIndex = 1;
             this.chkIgnoreInfObjectsCM.Text = "Ignore inferred objects";
             this.toolTip1.SetToolTip(this.chkIgnoreInfObjectsCM, "If checked, objects whose lifetime is controlled by the server (RowNumber, attrib" +
@@ -470,9 +497,10 @@
             // chkIgnoreTimestampsCM
             // 
             this.chkIgnoreTimestampsCM.AutoSize = true;
-            this.chkIgnoreTimestampsCM.Location = new System.Drawing.Point(6, 42);
+            this.chkIgnoreTimestampsCM.Location = new System.Drawing.Point(8, 52);
+            this.chkIgnoreTimestampsCM.Margin = new System.Windows.Forms.Padding(4);
             this.chkIgnoreTimestampsCM.Name = "chkIgnoreTimestampsCM";
-            this.chkIgnoreTimestampsCM.Size = new System.Drawing.Size(111, 17);
+            this.chkIgnoreTimestampsCM.Size = new System.Drawing.Size(145, 21);
             this.chkIgnoreTimestampsCM.TabIndex = 0;
             this.chkIgnoreTimestampsCM.Text = "Ignore timestamps";
             this.toolTip1.SetToolTip(this.chkIgnoreTimestampsCM, "If checked, editing timestamps are not serialized into the .json files");
@@ -485,18 +513,20 @@
             this.cmbSeparators.Items.AddRange(new object[] {
             "US/UK (A, B, C / 1.234)",
             "Others (A; B; C / 1,234)"});
-            this.cmbSeparators.Location = new System.Drawing.Point(7, 20);
+            this.cmbSeparators.Location = new System.Drawing.Point(9, 25);
+            this.cmbSeparators.Margin = new System.Windows.Forms.Padding(4);
             this.cmbSeparators.Name = "cmbSeparators";
-            this.cmbSeparators.Size = new System.Drawing.Size(179, 21);
+            this.cmbSeparators.Size = new System.Drawing.Size(237, 24);
             this.cmbSeparators.TabIndex = 0;
             this.toolTip1.SetToolTip(this.cmbSeparators, resources.GetString("cmbSeparators.ToolTip"));
             // 
             // chkBackgroundBpa
             // 
             this.chkBackgroundBpa.AutoSize = true;
-            this.chkBackgroundBpa.Location = new System.Drawing.Point(6, 44);
+            this.chkBackgroundBpa.Location = new System.Drawing.Point(8, 54);
+            this.chkBackgroundBpa.Margin = new System.Windows.Forms.Padding(4);
             this.chkBackgroundBpa.Name = "chkBackgroundBpa";
-            this.chkBackgroundBpa.Size = new System.Drawing.Size(223, 17);
+            this.chkBackgroundBpa.Size = new System.Drawing.Size(292, 21);
             this.chkBackgroundBpa.TabIndex = 1;
             this.chkBackgroundBpa.Text = "Background scan for Best Practice issues";
             this.toolTip1.SetToolTip(this.chkBackgroundBpa, "Checking this, will let you edit all TOM objects and properties when connected to" +
@@ -506,22 +536,51 @@
             // chkAnnotateDeploymentMetadata
             // 
             this.chkAnnotateDeploymentMetadata.AutoSize = true;
-            this.chkAnnotateDeploymentMetadata.Location = new System.Drawing.Point(7, 20);
+            this.chkAnnotateDeploymentMetadata.Location = new System.Drawing.Point(9, 25);
+            this.chkAnnotateDeploymentMetadata.Margin = new System.Windows.Forms.Padding(4);
             this.chkAnnotateDeploymentMetadata.Name = "chkAnnotateDeploymentMetadata";
-            this.chkAnnotateDeploymentMetadata.Size = new System.Drawing.Size(229, 17);
+            this.chkAnnotateDeploymentMetadata.Size = new System.Drawing.Size(302, 21);
             this.chkAnnotateDeploymentMetadata.TabIndex = 9;
             this.chkAnnotateDeploymentMetadata.Text = "Add metadata annotation upon deployment";
             this.toolTip1.SetToolTip(this.chkAnnotateDeploymentMetadata, resources.GetString("chkAnnotateDeploymentMetadata.ToolTip"));
             this.chkAnnotateDeploymentMetadata.UseVisualStyleBackColor = true;
+            // 
+            // chkIgnoreLineageTags
+            // 
+            this.chkIgnoreLineageTags.AutoSize = true;
+            this.chkIgnoreLineageTags.Location = new System.Drawing.Point(8, 80);
+            this.chkIgnoreLineageTags.Margin = new System.Windows.Forms.Padding(4);
+            this.chkIgnoreLineageTags.Name = "chkIgnoreLineageTags";
+            this.chkIgnoreLineageTags.Size = new System.Drawing.Size(151, 21);
+            this.chkIgnoreLineageTags.TabIndex = 4;
+            this.chkIgnoreLineageTags.Text = "Ignore lineage tags";
+            this.toolTip1.SetToolTip(this.chkIgnoreLineageTags, "If checked, expressions and other multiline string properties are serialized as a" +
+        " JSON array.");
+            this.chkIgnoreLineageTags.UseVisualStyleBackColor = true;
+            // 
+            // chkIgnoreLineageTagsCM
+            // 
+            this.chkIgnoreLineageTagsCM.AutoSize = true;
+            this.chkIgnoreLineageTagsCM.Location = new System.Drawing.Point(8, 80);
+            this.chkIgnoreLineageTagsCM.Margin = new System.Windows.Forms.Padding(4);
+            this.chkIgnoreLineageTagsCM.Name = "chkIgnoreLineageTagsCM";
+            this.chkIgnoreLineageTagsCM.Size = new System.Drawing.Size(151, 21);
+            this.chkIgnoreLineageTagsCM.TabIndex = 5;
+            this.chkIgnoreLineageTagsCM.Text = "Ignore lineage tags";
+            this.toolTip1.SetToolTip(this.chkIgnoreLineageTagsCM, "If checked, expressions and other multiline string properties are serialized as a" +
+        " JSON array.");
+            this.chkIgnoreLineageTagsCM.UseVisualStyleBackColor = true;
             // 
             // groupBox3
             // 
             this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox3.Controls.Add(this.chkFixup);
-            this.groupBox3.Location = new System.Drawing.Point(6, 6);
+            this.groupBox3.Location = new System.Drawing.Point(8, 7);
+            this.groupBox3.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(357, 49);
+            this.groupBox3.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox3.Size = new System.Drawing.Size(476, 60);
             this.groupBox3.TabIndex = 4;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Editing";
@@ -536,10 +595,11 @@
             this.tabControl1.Controls.Add(this.tabDAX);
             this.tabControl1.Controls.Add(this.tabSerialization);
             this.tabControl1.Controls.Add(this.tabCurrentModel);
-            this.tabControl1.Location = new System.Drawing.Point(12, 12);
+            this.tabControl1.Location = new System.Drawing.Point(16, 15);
+            this.tabControl1.Margin = new System.Windows.Forms.Padding(4);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(377, 389);
+            this.tabControl1.Size = new System.Drawing.Size(503, 479);
             this.tabControl1.TabIndex = 2;
             // 
             // tabFeatures
@@ -547,10 +607,11 @@
             this.tabFeatures.Controls.Add(this.grpDeployment);
             this.tabFeatures.Controls.Add(this.groupBox7);
             this.tabFeatures.Controls.Add(this.groupBox6);
-            this.tabFeatures.Location = new System.Drawing.Point(4, 22);
+            this.tabFeatures.Location = new System.Drawing.Point(4, 25);
+            this.tabFeatures.Margin = new System.Windows.Forms.Padding(4);
             this.tabFeatures.Name = "tabFeatures";
-            this.tabFeatures.Padding = new System.Windows.Forms.Padding(3);
-            this.tabFeatures.Size = new System.Drawing.Size(369, 363);
+            this.tabFeatures.Padding = new System.Windows.Forms.Padding(4);
+            this.tabFeatures.Size = new System.Drawing.Size(495, 450);
             this.tabFeatures.TabIndex = 2;
             this.tabFeatures.Text = "Features";
             this.tabFeatures.UseVisualStyleBackColor = true;
@@ -563,9 +624,11 @@
             this.grpDeployment.Controls.Add(this.btnFolder);
             this.grpDeployment.Controls.Add(this.txtBackupPath);
             this.grpDeployment.Controls.Add(this.chkAutoBackup);
-            this.grpDeployment.Location = new System.Drawing.Point(6, 180);
+            this.grpDeployment.Location = new System.Drawing.Point(8, 222);
+            this.grpDeployment.Margin = new System.Windows.Forms.Padding(4);
             this.grpDeployment.Name = "grpDeployment";
-            this.grpDeployment.Size = new System.Drawing.Size(356, 98);
+            this.grpDeployment.Padding = new System.Windows.Forms.Padding(4);
+            this.grpDeployment.Size = new System.Drawing.Size(475, 121);
             this.grpDeployment.TabIndex = 7;
             this.grpDeployment.TabStop = false;
             this.grpDeployment.Text = "Deployment Options";
@@ -574,9 +637,10 @@
             // 
             this.btnFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnFolder.Enabled = false;
-            this.btnFolder.Location = new System.Drawing.Point(323, 67);
+            this.btnFolder.Location = new System.Drawing.Point(431, 82);
+            this.btnFolder.Margin = new System.Windows.Forms.Padding(4);
             this.btnFolder.Name = "btnFolder";
-            this.btnFolder.Size = new System.Drawing.Size(27, 20);
+            this.btnFolder.Size = new System.Drawing.Size(36, 25);
             this.btnFolder.TabIndex = 8;
             this.btnFolder.Text = "...";
             this.btnFolder.UseVisualStyleBackColor = true;
@@ -587,9 +651,10 @@
             this.txtBackupPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtBackupPath.Enabled = false;
-            this.txtBackupPath.Location = new System.Drawing.Point(6, 67);
+            this.txtBackupPath.Location = new System.Drawing.Point(8, 82);
+            this.txtBackupPath.Margin = new System.Windows.Forms.Padding(4);
             this.txtBackupPath.Name = "txtBackupPath";
-            this.txtBackupPath.Size = new System.Drawing.Size(311, 20);
+            this.txtBackupPath.Size = new System.Drawing.Size(413, 22);
             this.txtBackupPath.TabIndex = 7;
             // 
             // groupBox7
@@ -600,9 +665,11 @@
             this.groupBox7.Controls.Add(this.chkCopyIncludeRLS);
             this.groupBox7.Controls.Add(this.chkCopyIncludePerspectives);
             this.groupBox7.Controls.Add(this.chkCopyIncludeTranslations);
-            this.groupBox7.Location = new System.Drawing.Point(6, 109);
+            this.groupBox7.Location = new System.Drawing.Point(8, 134);
+            this.groupBox7.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox7.Name = "groupBox7";
-            this.groupBox7.Size = new System.Drawing.Size(357, 65);
+            this.groupBox7.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox7.Size = new System.Drawing.Size(476, 80);
             this.groupBox7.TabIndex = 6;
             this.groupBox7.TabStop = false;
             this.groupBox7.Text = "Clipboard Operations";
@@ -614,9 +681,11 @@
             this.groupBox6.Controls.Add(this.chkBackgroundBpa);
             this.groupBox6.Controls.Add(this.chkAllowUnsupportedPBIFeatures);
             this.groupBox6.Controls.Add(this.chkChangeDetectionLocalServer);
-            this.groupBox6.Location = new System.Drawing.Point(6, 6);
+            this.groupBox6.Location = new System.Drawing.Point(8, 7);
+            this.groupBox6.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox6.Name = "groupBox6";
-            this.groupBox6.Size = new System.Drawing.Size(357, 97);
+            this.groupBox6.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox6.Size = new System.Drawing.Size(476, 119);
             this.groupBox6.TabIndex = 2;
             this.groupBox6.TabStop = false;
             this.groupBox6.Text = "Features";
@@ -626,10 +695,11 @@
             this.tabGeneral.Controls.Add(this.groupBox10);
             this.tabGeneral.Controls.Add(this.groupBox9);
             this.tabGeneral.Controls.Add(this.groupBox1);
-            this.tabGeneral.Location = new System.Drawing.Point(4, 22);
+            this.tabGeneral.Location = new System.Drawing.Point(4, 25);
+            this.tabGeneral.Margin = new System.Windows.Forms.Padding(4);
             this.tabGeneral.Name = "tabGeneral";
-            this.tabGeneral.Padding = new System.Windows.Forms.Padding(3);
-            this.tabGeneral.Size = new System.Drawing.Size(369, 363);
+            this.tabGeneral.Padding = new System.Windows.Forms.Padding(4);
+            this.tabGeneral.Size = new System.Drawing.Size(495, 450);
             this.tabGeneral.TabIndex = 6;
             this.tabGeneral.Text = "General";
             this.tabGeneral.UseVisualStyleBackColor = true;
@@ -641,9 +711,11 @@
             this.groupBox10.Controls.Add(this.txtCompilerOptions);
             this.groupBox10.Controls.Add(this.label6);
             this.groupBox10.Controls.Add(this.txtCompilerPath);
-            this.groupBox10.Location = new System.Drawing.Point(6, 138);
+            this.groupBox10.Location = new System.Drawing.Point(8, 170);
+            this.groupBox10.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox10.Name = "groupBox10";
-            this.groupBox10.Size = new System.Drawing.Size(357, 114);
+            this.groupBox10.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox10.Size = new System.Drawing.Size(476, 140);
             this.groupBox10.TabIndex = 4;
             this.groupBox10.TabStop = false;
             this.groupBox10.Text = "Advanced Scripting";
@@ -651,9 +723,10 @@
             // linkLabel1
             // 
             this.linkLabel1.LinkArea = new System.Windows.Forms.LinkArea(127, 9);
-            this.linkLabel1.Location = new System.Drawing.Point(6, 22);
+            this.linkLabel1.Location = new System.Drawing.Point(8, 27);
+            this.linkLabel1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.linkLabel1.Name = "linkLabel1";
-            this.linkLabel1.Size = new System.Drawing.Size(351, 30);
+            this.linkLabel1.Size = new System.Drawing.Size(468, 37);
             this.linkLabel1.TabIndex = 13;
             this.linkLabel1.TabStop = true;
             this.linkLabel1.Text = "To use new C# language features when scripting, you must configure Tabular Editor" +
@@ -664,33 +737,37 @@
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(6, 91);
+            this.label7.Location = new System.Drawing.Point(8, 112);
+            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(87, 13);
+            this.label7.Size = new System.Drawing.Size(117, 17);
             this.label7.TabIndex = 11;
             this.label7.Text = "Compiler options:";
             // 
             // txtCompilerOptions
             // 
-            this.txtCompilerOptions.Location = new System.Drawing.Point(99, 88);
+            this.txtCompilerOptions.Location = new System.Drawing.Point(132, 108);
+            this.txtCompilerOptions.Margin = new System.Windows.Forms.Padding(4);
             this.txtCompilerOptions.Name = "txtCompilerOptions";
-            this.txtCompilerOptions.Size = new System.Drawing.Size(252, 20);
+            this.txtCompilerOptions.Size = new System.Drawing.Size(335, 22);
             this.txtCompilerOptions.TabIndex = 10;
             // 
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(6, 65);
+            this.label6.Location = new System.Drawing.Point(8, 80);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(74, 13);
+            this.label6.Size = new System.Drawing.Size(99, 17);
             this.label6.TabIndex = 9;
             this.label6.Text = "Compiler path:";
             // 
             // txtCompilerPath
             // 
-            this.txtCompilerPath.Location = new System.Drawing.Point(99, 62);
+            this.txtCompilerPath.Location = new System.Drawing.Point(132, 76);
+            this.txtCompilerPath.Margin = new System.Windows.Forms.Padding(4);
             this.txtCompilerPath.Name = "txtCompilerPath";
-            this.txtCompilerPath.Size = new System.Drawing.Size(252, 20);
+            this.txtCompilerPath.Size = new System.Drawing.Size(335, 22);
             this.txtCompilerPath.TabIndex = 8;
             // 
             // groupBox9
@@ -702,9 +779,11 @@
             this.groupBox9.Controls.Add(this.txtProxyUser);
             this.groupBox9.Controls.Add(this.txtProxyAddress);
             this.groupBox9.Controls.Add(this.chkSystemProxy);
-            this.groupBox9.Location = new System.Drawing.Point(6, 6);
+            this.groupBox9.Location = new System.Drawing.Point(8, 7);
+            this.groupBox9.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox9.Name = "groupBox9";
-            this.groupBox9.Size = new System.Drawing.Size(357, 126);
+            this.groupBox9.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox9.Size = new System.Drawing.Size(476, 155);
             this.groupBox9.TabIndex = 3;
             this.groupBox9.TabStop = false;
             this.groupBox9.Text = "Proxy settings";
@@ -712,53 +791,59 @@
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(6, 98);
+            this.label5.Location = new System.Drawing.Point(8, 121);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(56, 13);
+            this.label5.Size = new System.Drawing.Size(73, 17);
             this.label5.TabIndex = 9;
             this.label5.Text = "Password:";
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(6, 72);
+            this.label4.Location = new System.Drawing.Point(8, 89);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(58, 13);
+            this.label4.Size = new System.Drawing.Size(77, 17);
             this.label4.TabIndex = 8;
             this.label4.Text = "Username:";
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(6, 46);
+            this.label3.Location = new System.Drawing.Point(8, 57);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(76, 13);
+            this.label3.Size = new System.Drawing.Size(102, 17);
             this.label3.TabIndex = 7;
             this.label3.Text = "Proxy address:";
             // 
             // txtProxyPassword
             // 
             this.txtProxyPassword.Enabled = false;
-            this.txtProxyPassword.Location = new System.Drawing.Point(99, 95);
+            this.txtProxyPassword.Location = new System.Drawing.Point(132, 117);
+            this.txtProxyPassword.Margin = new System.Windows.Forms.Padding(4);
             this.txtProxyPassword.Name = "txtProxyPassword";
             this.txtProxyPassword.PasswordChar = '●';
-            this.txtProxyPassword.Size = new System.Drawing.Size(141, 20);
+            this.txtProxyPassword.Size = new System.Drawing.Size(187, 22);
             this.txtProxyPassword.TabIndex = 6;
             // 
             // txtProxyUser
             // 
             this.txtProxyUser.Enabled = false;
-            this.txtProxyUser.Location = new System.Drawing.Point(99, 69);
+            this.txtProxyUser.Location = new System.Drawing.Point(132, 85);
+            this.txtProxyUser.Margin = new System.Windows.Forms.Padding(4);
             this.txtProxyUser.Name = "txtProxyUser";
-            this.txtProxyUser.Size = new System.Drawing.Size(141, 20);
+            this.txtProxyUser.Size = new System.Drawing.Size(187, 22);
             this.txtProxyUser.TabIndex = 5;
             // 
             // txtProxyAddress
             // 
             this.txtProxyAddress.Enabled = false;
-            this.txtProxyAddress.Location = new System.Drawing.Point(99, 43);
+            this.txtProxyAddress.Location = new System.Drawing.Point(132, 53);
+            this.txtProxyAddress.Margin = new System.Windows.Forms.Padding(4);
             this.txtProxyAddress.Name = "txtProxyAddress";
-            this.txtProxyAddress.Size = new System.Drawing.Size(252, 20);
+            this.txtProxyAddress.Size = new System.Drawing.Size(335, 22);
             this.txtProxyAddress.TabIndex = 4;
             // 
             // chkSystemProxy
@@ -766,9 +851,10 @@
             this.chkSystemProxy.AutoSize = true;
             this.chkSystemProxy.Checked = true;
             this.chkSystemProxy.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkSystemProxy.Location = new System.Drawing.Point(7, 20);
+            this.chkSystemProxy.Location = new System.Drawing.Point(9, 25);
+            this.chkSystemProxy.Margin = new System.Windows.Forms.Padding(4);
             this.chkSystemProxy.Name = "chkSystemProxy";
-            this.chkSystemProxy.Size = new System.Drawing.Size(108, 17);
+            this.chkSystemProxy.Size = new System.Drawing.Size(141, 21);
             this.chkSystemProxy.TabIndex = 0;
             this.chkSystemProxy.Text = "Use system proxy";
             this.chkSystemProxy.UseVisualStyleBackColor = true;
@@ -783,9 +869,11 @@
             this.groupBox1.Controls.Add(this.btnVersionCheck);
             this.groupBox1.Controls.Add(this.lblAvailableVersion);
             this.groupBox1.Controls.Add(this.lblCurrentVersion);
-            this.groupBox1.Location = new System.Drawing.Point(6, 258);
+            this.groupBox1.Location = new System.Drawing.Point(8, 318);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(357, 99);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox1.Size = new System.Drawing.Size(476, 122);
             this.groupBox1.TabIndex = 2;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Tabular Editor Updates";
@@ -793,9 +881,10 @@
             // chkAutoUpdate
             // 
             this.chkAutoUpdate.AutoSize = true;
-            this.chkAutoUpdate.Location = new System.Drawing.Point(6, 75);
+            this.chkAutoUpdate.Location = new System.Drawing.Point(8, 92);
+            this.chkAutoUpdate.Margin = new System.Windows.Forms.Padding(4);
             this.chkAutoUpdate.Name = "chkAutoUpdate";
-            this.chkAutoUpdate.Size = new System.Drawing.Size(204, 17);
+            this.chkAutoUpdate.Size = new System.Drawing.Size(269, 21);
             this.chkAutoUpdate.TabIndex = 4;
             this.chkAutoUpdate.Text = "Check for updated version on start-up";
             this.chkAutoUpdate.UseVisualStyleBackColor = true;
@@ -804,18 +893,20 @@
             // chkSkipPatch
             // 
             this.chkSkipPatch.AutoSize = true;
-            this.chkSkipPatch.Location = new System.Drawing.Point(230, 75);
+            this.chkSkipPatch.Location = new System.Drawing.Point(307, 92);
+            this.chkSkipPatch.Margin = new System.Windows.Forms.Padding(4);
             this.chkSkipPatch.Name = "chkSkipPatch";
-            this.chkSkipPatch.Size = new System.Drawing.Size(107, 17);
+            this.chkSkipPatch.Size = new System.Drawing.Size(137, 21);
             this.chkSkipPatch.TabIndex = 5;
             this.chkSkipPatch.Text = "Skip patch builds";
             this.chkSkipPatch.UseVisualStyleBackColor = true;
             // 
             // btnVersionCheck
             // 
-            this.btnVersionCheck.Location = new System.Drawing.Point(6, 46);
+            this.btnVersionCheck.Location = new System.Drawing.Point(8, 57);
+            this.btnVersionCheck.Margin = new System.Windows.Forms.Padding(4);
             this.btnVersionCheck.Name = "btnVersionCheck";
-            this.btnVersionCheck.Size = new System.Drawing.Size(126, 23);
+            this.btnVersionCheck.Size = new System.Drawing.Size(168, 28);
             this.btnVersionCheck.TabIndex = 3;
             this.btnVersionCheck.Text = "Check for updates";
             this.btnVersionCheck.UseVisualStyleBackColor = true;
@@ -827,9 +918,10 @@
             this.lblAvailableVersion.Cursor = System.Windows.Forms.Cursors.Hand;
             this.lblAvailableVersion.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblAvailableVersion.ForeColor = System.Drawing.SystemColors.HotTrack;
-            this.lblAvailableVersion.Location = new System.Drawing.Point(6, 51);
+            this.lblAvailableVersion.Location = new System.Drawing.Point(8, 63);
+            this.lblAvailableVersion.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblAvailableVersion.Name = "lblAvailableVersion";
-            this.lblAvailableVersion.Size = new System.Drawing.Size(126, 13);
+            this.lblAvailableVersion.Size = new System.Drawing.Size(167, 17);
             this.lblAvailableVersion.TabIndex = 2;
             this.lblAvailableVersion.Text = "Available version: 2.0.0.0";
             this.lblAvailableVersion.Visible = false;
@@ -838,9 +930,10 @@
             // lblCurrentVersion
             // 
             this.lblCurrentVersion.AutoSize = true;
-            this.lblCurrentVersion.Location = new System.Drawing.Point(6, 26);
+            this.lblCurrentVersion.Location = new System.Drawing.Point(8, 32);
+            this.lblCurrentVersion.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblCurrentVersion.Name = "lblCurrentVersion";
-            this.lblCurrentVersion.Size = new System.Drawing.Size(117, 13);
+            this.lblCurrentVersion.Size = new System.Drawing.Size(157, 17);
             this.lblCurrentVersion.TabIndex = 1;
             this.lblCurrentVersion.Text = "Current version: 2.0.0.0";
             // 
@@ -848,10 +941,11 @@
             // 
             this.tabDAX.Controls.Add(this.groupBox5);
             this.tabDAX.Controls.Add(this.groupBox3);
-            this.tabDAX.Location = new System.Drawing.Point(4, 22);
+            this.tabDAX.Location = new System.Drawing.Point(4, 25);
+            this.tabDAX.Margin = new System.Windows.Forms.Padding(4);
             this.tabDAX.Name = "tabDAX";
-            this.tabDAX.Padding = new System.Windows.Forms.Padding(3);
-            this.tabDAX.Size = new System.Drawing.Size(369, 363);
+            this.tabDAX.Padding = new System.Windows.Forms.Padding(4);
+            this.tabDAX.Size = new System.Drawing.Size(495, 450);
             this.tabDAX.TabIndex = 1;
             this.tabDAX.Text = "DAX";
             this.tabDAX.UseVisualStyleBackColor = true;
@@ -861,9 +955,11 @@
             this.groupBox5.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox5.Controls.Add(this.cmbSeparators);
-            this.groupBox5.Location = new System.Drawing.Point(6, 62);
+            this.groupBox5.Location = new System.Drawing.Point(8, 76);
+            this.groupBox5.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox5.Name = "groupBox5";
-            this.groupBox5.Size = new System.Drawing.Size(357, 53);
+            this.groupBox5.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox5.Size = new System.Drawing.Size(476, 65);
             this.groupBox5.TabIndex = 5;
             this.groupBox5.TabStop = false;
             this.groupBox5.Text = "Separators";
@@ -872,10 +968,11 @@
             // 
             this.tabSerialization.Controls.Add(this.groupBox4);
             this.tabSerialization.Controls.Add(this.groupBox2);
-            this.tabSerialization.Location = new System.Drawing.Point(4, 22);
+            this.tabSerialization.Location = new System.Drawing.Point(4, 25);
+            this.tabSerialization.Margin = new System.Windows.Forms.Padding(4);
             this.tabSerialization.Name = "tabSerialization";
-            this.tabSerialization.Padding = new System.Windows.Forms.Padding(3);
-            this.tabSerialization.Size = new System.Drawing.Size(369, 363);
+            this.tabSerialization.Padding = new System.Windows.Forms.Padding(4);
+            this.tabSerialization.Size = new System.Drawing.Size(495, 450);
             this.tabSerialization.TabIndex = 3;
             this.tabSerialization.Text = "Serialization";
             this.tabSerialization.UseVisualStyleBackColor = true;
@@ -885,18 +982,32 @@
             this.groupBox4.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox4.Controls.Add(this.chkAlsoSaveAsBim);
             this.groupBox4.Controls.Add(this.chkPrefixFiles);
             this.groupBox4.Controls.Add(this.chkLocalRelationships);
             this.groupBox4.Controls.Add(this.chkLocalTranslations);
             this.groupBox4.Controls.Add(this.chkLocalPerspectives);
             this.groupBox4.Controls.Add(this.treeView1);
             this.groupBox4.Controls.Add(this.label1);
-            this.groupBox4.Location = new System.Drawing.Point(6, 98);
+            this.groupBox4.Location = new System.Drawing.Point(8, 121);
+            this.groupBox4.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(357, 262);
+            this.groupBox4.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox4.Size = new System.Drawing.Size(476, 322);
             this.groupBox4.TabIndex = 4;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Save to Folder Serialization";
+            // 
+            // chkAlsoSaveAsBim
+            // 
+            this.chkAlsoSaveAsBim.AutoSize = true;
+            this.chkAlsoSaveAsBim.Location = new System.Drawing.Point(191, 23);
+            this.chkAlsoSaveAsBim.Name = "chkAlsoSaveAsBim";
+            this.chkAlsoSaveAsBim.Size = new System.Drawing.Size(140, 21);
+            this.chkAlsoSaveAsBim.TabIndex = 5;
+            this.chkAlsoSaveAsBim.Text = "Also save as .bim";
+            this.toolTip1.SetToolTip(this.chkAlsoSaveAsBim, "If checked, a .bim file will be saved along with the folder serialized version.");
+            this.chkAlsoSaveAsBim.UseVisualStyleBackColor = true;
             // 
             // treeView1
             // 
@@ -904,7 +1015,8 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.treeView1.CheckBoxes = true;
-            this.treeView1.Location = new System.Drawing.Point(6, 73);
+            this.treeView1.Location = new System.Drawing.Point(8, 90);
+            this.treeView1.Margin = new System.Windows.Forms.Padding(4);
             this.treeView1.Name = "treeView1";
             treeNode1.Checked = true;
             treeNode1.Name = "Data Sources";
@@ -950,7 +1062,7 @@
             treeNode12});
             this.treeView1.PathSeparator = "/";
             this.treeView1.ShowLines = false;
-            this.treeView1.Size = new System.Drawing.Size(345, 115);
+            this.treeView1.Size = new System.Drawing.Size(459, 141);
             this.treeView1.TabIndex = 1;
             this.treeView1.AfterCheck += new System.Windows.Forms.TreeViewEventHandler(this.treeView1_AfterCheck);
             // 
@@ -958,9 +1070,10 @@
             // 
             this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.label1.Location = new System.Drawing.Point(6, 39);
+            this.label1.Location = new System.Drawing.Point(8, 48);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(344, 31);
+            this.label1.Size = new System.Drawing.Size(459, 38);
             this.label1.TabIndex = 0;
             this.label1.Text = "Check the type of objects you wish to serialize as individual files (unchecked ob" +
     "jects are serialized in the parent object):";
@@ -974,9 +1087,11 @@
             this.groupBox2.Controls.Add(this.chkIgnoreInfProps);
             this.groupBox2.Controls.Add(this.chkIgnoreInfObjects);
             this.groupBox2.Controls.Add(this.chkIgnoreTimestamps);
-            this.groupBox2.Location = new System.Drawing.Point(6, 6);
+            this.groupBox2.Location = new System.Drawing.Point(8, 7);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(357, 86);
+            this.groupBox2.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox2.Size = new System.Drawing.Size(476, 106);
             this.groupBox2.TabIndex = 0;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "General Serialization Settings";
@@ -985,10 +1100,11 @@
             // 
             this.tabCurrentModel.Controls.Add(this.grpSaveToFolder);
             this.tabCurrentModel.Controls.Add(this.groupBox8);
-            this.tabCurrentModel.Location = new System.Drawing.Point(4, 22);
+            this.tabCurrentModel.Location = new System.Drawing.Point(4, 25);
+            this.tabCurrentModel.Margin = new System.Windows.Forms.Padding(4);
             this.tabCurrentModel.Name = "tabCurrentModel";
-            this.tabCurrentModel.Padding = new System.Windows.Forms.Padding(3);
-            this.tabCurrentModel.Size = new System.Drawing.Size(369, 363);
+            this.tabCurrentModel.Padding = new System.Windows.Forms.Padding(4);
+            this.tabCurrentModel.Size = new System.Drawing.Size(495, 450);
             this.tabCurrentModel.TabIndex = 5;
             this.tabCurrentModel.Text = "Current Model";
             this.tabCurrentModel.UseVisualStyleBackColor = true;
@@ -998,18 +1114,31 @@
             this.grpSaveToFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.grpSaveToFolder.Controls.Add(this.chkAlsoSaveAsBimCM);
             this.grpSaveToFolder.Controls.Add(this.chkPrefixFilesCM);
             this.grpSaveToFolder.Controls.Add(this.chkLocalRelationshipsCM);
             this.grpSaveToFolder.Controls.Add(this.chkLocalTranslationsCM);
             this.grpSaveToFolder.Controls.Add(this.chkLocalPerspectivesCM);
             this.grpSaveToFolder.Controls.Add(this.treeView2);
             this.grpSaveToFolder.Controls.Add(this.label2);
-            this.grpSaveToFolder.Location = new System.Drawing.Point(6, 98);
+            this.grpSaveToFolder.Location = new System.Drawing.Point(8, 121);
+            this.grpSaveToFolder.Margin = new System.Windows.Forms.Padding(4);
             this.grpSaveToFolder.Name = "grpSaveToFolder";
-            this.grpSaveToFolder.Size = new System.Drawing.Size(357, 262);
+            this.grpSaveToFolder.Padding = new System.Windows.Forms.Padding(4);
+            this.grpSaveToFolder.Size = new System.Drawing.Size(476, 322);
             this.grpSaveToFolder.TabIndex = 6;
             this.grpSaveToFolder.TabStop = false;
             this.grpSaveToFolder.Text = "Current Model \"Save to Folder\" Settings";
+            // 
+            // chkAlsoSaveAsBimCM
+            // 
+            this.chkAlsoSaveAsBimCM.AutoSize = true;
+            this.chkAlsoSaveAsBimCM.Location = new System.Drawing.Point(191, 23);
+            this.chkAlsoSaveAsBimCM.Name = "chkAlsoSaveAsBimCM";
+            this.chkAlsoSaveAsBimCM.Size = new System.Drawing.Size(140, 21);
+            this.chkAlsoSaveAsBimCM.TabIndex = 11;
+            this.chkAlsoSaveAsBimCM.Text = "Also save as .bim";
+            this.chkAlsoSaveAsBimCM.UseVisualStyleBackColor = true;
             // 
             // treeView2
             // 
@@ -1017,7 +1146,8 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.treeView2.CheckBoxes = true;
-            this.treeView2.Location = new System.Drawing.Point(6, 73);
+            this.treeView2.Location = new System.Drawing.Point(8, 90);
+            this.treeView2.Margin = new System.Windows.Forms.Padding(4);
             this.treeView2.Name = "treeView2";
             treeNode13.Checked = true;
             treeNode13.Name = "Data Sources";
@@ -1063,7 +1193,7 @@
             treeNode24});
             this.treeView2.PathSeparator = "/";
             this.treeView2.ShowLines = false;
-            this.treeView2.Size = new System.Drawing.Size(345, 115);
+            this.treeView2.Size = new System.Drawing.Size(459, 141);
             this.treeView2.TabIndex = 1;
             this.treeView2.AfterCheck += new System.Windows.Forms.TreeViewEventHandler(this.treeView2_AfterCheck);
             // 
@@ -1071,9 +1201,10 @@
             // 
             this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.label2.Location = new System.Drawing.Point(6, 39);
+            this.label2.Location = new System.Drawing.Point(8, 48);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(344, 31);
+            this.label2.Size = new System.Drawing.Size(459, 38);
             this.label2.TabIndex = 0;
             this.label2.Text = "Check the type of objects you wish to serialize as individual files (unchecked ob" +
     "jects are serialized in the parent object):";
@@ -1087,51 +1218,30 @@
             this.groupBox8.Controls.Add(this.chkIgnoreInfPropsCM);
             this.groupBox8.Controls.Add(this.chkIgnoreInfObjectsCM);
             this.groupBox8.Controls.Add(this.chkIgnoreTimestampsCM);
-            this.groupBox8.Location = new System.Drawing.Point(6, 6);
+            this.groupBox8.Location = new System.Drawing.Point(8, 7);
+            this.groupBox8.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox8.Name = "groupBox8";
-            this.groupBox8.Size = new System.Drawing.Size(357, 86);
+            this.groupBox8.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox8.Size = new System.Drawing.Size(476, 106);
             this.groupBox8.TabIndex = 5;
             this.groupBox8.TabStop = false;
             this.groupBox8.Text = "Current Model Serialization Settings";
             // 
-            // chkIgnoreLineageTags
-            // 
-            this.chkIgnoreLineageTags.AutoSize = true;
-            this.chkIgnoreLineageTags.Location = new System.Drawing.Point(6, 65);
-            this.chkIgnoreLineageTags.Name = "chkIgnoreLineageTags";
-            this.chkIgnoreLineageTags.Size = new System.Drawing.Size(116, 17);
-            this.chkIgnoreLineageTags.TabIndex = 4;
-            this.chkIgnoreLineageTags.Text = "Ignore lineage tags";
-            this.toolTip1.SetToolTip(this.chkIgnoreLineageTags, "If checked, expressions and other multiline string properties are serialized as a" +
-        " JSON array.");
-            this.chkIgnoreLineageTags.UseVisualStyleBackColor = true;
-            // 
-            // chkIgnoreLineageTagsCM
-            // 
-            this.chkIgnoreLineageTagsCM.AutoSize = true;
-            this.chkIgnoreLineageTagsCM.Location = new System.Drawing.Point(6, 65);
-            this.chkIgnoreLineageTagsCM.Name = "chkIgnoreLineageTagsCM";
-            this.chkIgnoreLineageTagsCM.Size = new System.Drawing.Size(116, 17);
-            this.chkIgnoreLineageTagsCM.TabIndex = 5;
-            this.chkIgnoreLineageTagsCM.Text = "Ignore lineage tags";
-            this.toolTip1.SetToolTip(this.chkIgnoreLineageTagsCM, "If checked, expressions and other multiline string properties are serialized as a" +
-        " JSON array.");
-            this.chkIgnoreLineageTagsCM.UseVisualStyleBackColor = true;
-            // 
             // PreferencesForm
             // 
             this.AcceptButton = this.btnOK;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(401, 442);
+            this.ClientSize = new System.Drawing.Size(535, 544);
             this.Controls.Add(this.tabControl1);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOK);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(417, 481);
+            this.MinimumSize = new System.Drawing.Size(550, 581);
             this.Name = "PreferencesForm";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
@@ -1245,5 +1355,7 @@
         private System.Windows.Forms.TextBox txtCompilerPath;
         private System.Windows.Forms.CheckBox chkIgnoreLineageTags;
         private System.Windows.Forms.CheckBox chkIgnoreLineageTagsCM;
+        private System.Windows.Forms.CheckBox chkAlsoSaveAsBim;
+        private System.Windows.Forms.CheckBox chkAlsoSaveAsBimCM;
     }
 }

--- a/TabularEditor/UI/Dialogs/PreferencesForm.Designer.cs
+++ b/TabularEditor/UI/Dialogs/PreferencesForm.Designer.cs
@@ -98,6 +98,7 @@
             this.chkAnnotateDeploymentMetadata = new System.Windows.Forms.CheckBox();
             this.chkIgnoreLineageTags = new System.Windows.Forms.CheckBox();
             this.chkIgnoreLineageTagsCM = new System.Windows.Forms.CheckBox();
+            this.chkAlsoSaveAsBim = new System.Windows.Forms.CheckBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabFeatures = new System.Windows.Forms.TabPage();
@@ -131,7 +132,6 @@
             this.groupBox5 = new System.Windows.Forms.GroupBox();
             this.tabSerialization = new System.Windows.Forms.TabPage();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
-            this.chkAlsoSaveAsBim = new System.Windows.Forms.CheckBox();
             this.treeView1 = new System.Windows.Forms.TreeView();
             this.label1 = new System.Windows.Forms.Label();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
@@ -571,6 +571,17 @@
         " JSON array.");
             this.chkIgnoreLineageTagsCM.UseVisualStyleBackColor = true;
             // 
+            // chkAlsoSaveAsBim
+            // 
+            this.chkAlsoSaveAsBim.AutoSize = true;
+            this.chkAlsoSaveAsBim.Location = new System.Drawing.Point(191, 23);
+            this.chkAlsoSaveAsBim.Name = "chkAlsoSaveAsBim";
+            this.chkAlsoSaveAsBim.Size = new System.Drawing.Size(140, 21);
+            this.chkAlsoSaveAsBim.TabIndex = 5;
+            this.chkAlsoSaveAsBim.Text = "Also save as .bim";
+            this.toolTip1.SetToolTip(this.chkAlsoSaveAsBim, "If checked, a .bim file will be saved along with the folder serialized version.");
+            this.chkAlsoSaveAsBim.UseVisualStyleBackColor = true;
+            // 
             // groupBox3
             // 
             this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
@@ -998,17 +1009,6 @@
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Save to Folder Serialization";
             // 
-            // chkAlsoSaveAsBim
-            // 
-            this.chkAlsoSaveAsBim.AutoSize = true;
-            this.chkAlsoSaveAsBim.Location = new System.Drawing.Point(191, 23);
-            this.chkAlsoSaveAsBim.Name = "chkAlsoSaveAsBim";
-            this.chkAlsoSaveAsBim.Size = new System.Drawing.Size(140, 21);
-            this.chkAlsoSaveAsBim.TabIndex = 5;
-            this.chkAlsoSaveAsBim.Text = "Also save as .bim";
-            this.toolTip1.SetToolTip(this.chkAlsoSaveAsBim, "If checked, a .bim file will be saved along with the folder serialized version.");
-            this.chkAlsoSaveAsBim.UseVisualStyleBackColor = true;
-            // 
             // treeView1
             // 
             this.treeView1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
@@ -1138,6 +1138,7 @@
             this.chkAlsoSaveAsBimCM.Size = new System.Drawing.Size(140, 21);
             this.chkAlsoSaveAsBimCM.TabIndex = 11;
             this.chkAlsoSaveAsBimCM.Text = "Also save as .bim";
+            this.toolTip1.SetToolTip(this.chkAlsoSaveAsBimCM, "If checked, a .bim file will be saved along with the folder serialized version.");
             this.chkAlsoSaveAsBimCM.UseVisualStyleBackColor = true;
             // 
             // treeView2

--- a/TabularEditor/UI/Dialogs/PreferencesForm.cs
+++ b/TabularEditor/UI/Dialogs/PreferencesForm.cs
@@ -133,6 +133,7 @@ namespace TabularEditor.UI.Dialogs
 
             LoadCheckedNodes(treeView2.Nodes, options.Levels);
             chkPrefixFilesCM.Checked = options.PrefixFilenames;
+            chkAlsoSaveAsBimCM.Checked = options.AlsoSaveAsBim;
             chkLocalPerspectivesCM.Checked = options.LocalPerspectives;
             chkLocalTranslationsCM.Checked = options.LocalTranslations;
             chkLocalRelationshipsCM.Checked = options.LocalRelationships;
@@ -159,6 +160,7 @@ namespace TabularEditor.UI.Dialogs
             Preferences.Current.IgnoreInferredProperties = chkIgnoreInfProps.Checked;
             Preferences.Current.SplitMultilineStrings = chkSplitMultiline.Checked;
             Preferences.Current.SaveToFolder_PrefixFiles = chkPrefixFiles.Checked;
+            Preferences.Current.SaveToFolder_AlsoSaveAsBim = chkAlsoSaveAsBim.Checked;
             Preferences.Current.SaveToFolder_LocalPerspectives = chkLocalPerspectives.Checked;
             Preferences.Current.SaveToFolder_LocalTranslations = chkLocalTranslations.Checked;
             Preferences.Current.SaveToFolder_LocalRelationships = chkLocalRelationships.Checked;
@@ -191,6 +193,7 @@ namespace TabularEditor.UI.Dialogs
             options.IgnoreInferredProperties = chkIgnoreInfPropsCM.Checked;
             options.SplitMultilineStrings = chkSplitMultilineCM.Checked;
             options.PrefixFilenames = chkPrefixFilesCM.Checked;
+            options.AlsoSaveAsBim = chkAlsoSaveAsBimCM.Checked;
             options.LocalPerspectives = chkLocalPerspectivesCM.Checked;
             options.LocalTranslations = chkLocalTranslationsCM.Checked;
             options.LocalRelationships = chkLocalRelationshipsCM.Checked;
@@ -238,6 +241,7 @@ namespace TabularEditor.UI.Dialogs
             chkSplitMultiline.Checked = Preferences.Current.SplitMultilineStrings;
 
             chkPrefixFiles.Checked = Preferences.Current.SaveToFolder_PrefixFiles;
+            chkAlsoSaveAsBim.Checked = Preferences.Current.SaveToFolder_AlsoSaveAsBim;
             chkLocalPerspectives.Checked = Preferences.Current.SaveToFolder_LocalPerspectives;
             chkLocalTranslations.Checked = Preferences.Current.SaveToFolder_LocalTranslations;
             chkLocalRelationships.Checked = Preferences.Current.SaveToFolder_LocalRelationships;

--- a/TabularEditor/UI/UIController_Files.cs
+++ b/TabularEditor/UI/UIController_Files.cs
@@ -389,6 +389,18 @@ namespace TabularEditor.UI
                         {
                             Handler.Save(File_Current, SaveFormat.TabularEditorFolder, null, true, true);
                             File_LastWrite = GetLastDirChange(File_Current);
+                            if (Handler.SerializeOptions.AlsoSaveAsBim)
+                            {
+                                try
+                                {
+                                    Handler.Save(File_Current + "\\model.bim", SaveFormat.ModelSchemaOnly, null, true, true);
+                                    File_LastWrite = File.GetLastWriteTime(File_Current);
+                                }
+                                catch (Exception e)
+                                {
+                                    HandleError("Could not save metadata to file", e);
+                                }
+                            }
                         }
                         catch (Exception e)
                         {
@@ -409,7 +421,7 @@ namespace TabularEditor.UI
                                 Handler.Save(File_Current, SaveFormat.PowerBiTemplate, SerializeOptions.PowerBi, false, true);
                             else
                                 Handler.Save(File_Current, SaveFormat.ModelSchemaOnly, null, true, true);
-                            File_LastWrite = File.GetLastWriteTime(File_Current);
+                                File_LastWrite = File.GetLastWriteTime(File_Current);
                         }
                         catch (Exception e)
                         {

--- a/TabularEditor/UIServices/Preferences.cs
+++ b/TabularEditor/UIServices/Preferences.cs
@@ -44,7 +44,7 @@ namespace TabularEditor.UIServices
         public bool IgnoreInferredProperties = true;
         public bool IgnoreTimestamps = true;
         public bool SplitMultilineStrings = true;
-        public bool IgnoreLineageTags = false;        
+        public bool IgnoreLineageTags = false;
 
         public bool ProxyUseSystem = true;
         public string ProxyAddress = string.Empty;

--- a/TabularEditor/UIServices/Preferences.cs
+++ b/TabularEditor/UIServices/Preferences.cs
@@ -44,7 +44,7 @@ namespace TabularEditor.UIServices
         public bool IgnoreInferredProperties = true;
         public bool IgnoreTimestamps = true;
         public bool SplitMultilineStrings = true;
-        public bool IgnoreLineageTags = false;
+        public bool IgnoreLineageTags = false;        
 
         public bool ProxyUseSystem = true;
         public string ProxyAddress = string.Empty;
@@ -83,6 +83,7 @@ namespace TabularEditor.UIServices
         #endregion
 
         public bool SaveToFolder_PrefixFiles = false;
+        public bool SaveToFolder_AlsoSaveAsBim = false;
         public bool SaveToFolder_LocalRelationships = false;
         public bool SaveToFolder_LocalPerspectives = false;
         public bool SaveToFolder_LocalTranslations = false;
@@ -246,6 +247,7 @@ namespace TabularEditor.UIServices
             };
 
             serializeOptions.PrefixFilenames = value.SaveToFolder_PrefixFiles;
+            serializeOptions.AlsoSaveAsBim = value.SaveToFolder_AlsoSaveAsBim;
             serializeOptions.LocalPerspectives = value.SaveToFolder_LocalPerspectives;
             serializeOptions.LocalTranslations = value.SaveToFolder_LocalTranslations;
             serializeOptions.LocalRelationships = value.SaveToFolder_LocalRelationships;


### PR DESCRIPTION
This is related to: https://github.com/TabularEditor/TabularEditor/issues/894

Adding a new feature so that any time you click Save when working with folder serialized models that both the folder serialized version and a normal .bim version can both be generated/saved at the same time.  Preferences have been added to toggle this behavior on/off and are defaulted to off.