### PR TITLE
Fix VERSION_MANIFEST_URL: use version.txt from master

### DIFF
--- a/TabularEditor/UIServices/UpdateService.cs
+++ b/TabularEditor/UIServices/UpdateService.cs
@@ -11,7 +11,7 @@ namespace TabularEditor.UIServices
 {
     public static class UpdateService
     {
-        public const string VERSION_MANIFEST_URL = "https://raw.githubusercontent.com/TabularEditor/TabularEditor/2.16.1/TabularEditor/version.txt";
+        public const string VERSION_MANIFEST_URL = "https://raw.githubusercontent.com/TabularEditor/TabularEditor/master/TabularEditor/version.txt";
         public const string DOWNLOAD_UPDATE_URL = "https://github.com/TabularEditor/TabularEditor/releases/latest";
 
         public static Version CurrentBuild { get; } = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;


### PR DESCRIPTION
Hi Daniel, this small change fixes #1031.

This is the commit where the bug was introduced: addeb4c54c355bdf6f82afcef64c316a87aa9f75