### PR TITLE
Fixed model saving error that occurs when database name and id do not match

### DIFF
--- a/TOMWrapper/TOMWrapper/Serialization/SplitModelSerializer.cs
+++ b/TOMWrapper/TOMWrapper/Serialization/SplitModelSerializer.cs
@@ -60,13 +60,13 @@ namespace TabularEditor.TOMWrapper.Serialization
                 if (model.Database != null)
                 {
                     if (!model.Database.Name.EqualsI(model.Database.ID)) jobj["id"] = model.Database.ID;
-                    else if (jobj["id"] != null) jobj["id"].Remove();
+                    else if (jobj["id"] != null) jobj["id"].Parent.Remove();
                 }
 
                 if (options.DatabaseNameOverride != null)
                 {
                     jobj["name"] = options.DatabaseNameOverride;
-                    if (jobj["id"] != null) jobj["id"].Remove();
+                    if (jobj["id"] != null) jobj["id"].Parent.Remove();
                 }
 
                 var jModel = jobj["model"] as JObject;


### PR DESCRIPTION
When saving a model that has different a database name and id, TabularEditor will display the error message 'Cannot add or remove items from Newtonsoft.Json.Linq.JProperty'. This is because TabularEditor attempts to remove the database id from the object model, but the call to the Remove method is referencing the property value for the database id. This is corrected by calling the database id's Parent Remove method. This allows the JProperty for the database id to be removed from the object model, as desired.