### PR TITLE
Selected API updates

### DIFF
--- a/TabularEditor/UI/UITreeSelection.cs
+++ b/TabularEditor/UI/UITreeSelection.cs
@@ -344,10 +344,9 @@ namespace TabularEditor.UI
 
         public UITreeSelection(IEnumerable<ITabularNamedObject> selection) : base(selection)
         {
-            Folders = this.OfType<Folder>();
             Groups = this.OfType<LogicalGroup>();
             Direct = new UISelectionList<ITabularNamedObject>(this.OfType<ITabularNamedObject>());
-            AssignCollections();
+            AssignCollections(this.OfType<Folder>());
         }
 
         public UITreeSelection(IReadOnlyCollection<TreeNodeAdv> selectedNodes)
@@ -362,18 +361,19 @@ namespace TabularEditor.UI
             else if (allNodes.Count == 1) Context = GetNodeContext(allNodes[0]);
             else Context = GetNodeContexts(allNodes);
 
-            Folders = selectedNodes.Select(n => n.Tag).OfType<Folder>();
             Groups = selectedNodes.Select(n => n.Tag).OfType<LogicalGroup>();
             Direct = new UISelectionList<ITabularNamedObject>(selectedNodes.Select(n => n.Tag).OfType<ITabularNamedObject>());
 
-            AssignCollections();
+            AssignCollections(selectedNodes.Select(n => n.Tag).OfType<Folder>());
         }
 
-        private void AssignCollections()
+        private void AssignCollections(IEnumerable<Folder> folders)
         {
+            Folders = new UISelectionList<Folder>(folders);
             Measures = new UISelectionList<Measure>(this.OfType<Measure>());
             Hierarchies = new UISelectionList<Hierarchy>(this.OfType<Hierarchy>());
             Levels = new UISelectionList<Level>(this.OfType<Level>());
+            KPIs = new UISelectionList<KPI>(this.OfType<KPI>());
             Columns = new UISelectionList<Column>(this.OfType<Column>());
             Cultures = new UISelectionList<Culture>(this.OfType<Culture>());
             Roles = new UISelectionList<ModelRole>(this.OfType<ModelRole>());
@@ -390,6 +390,7 @@ namespace TabularEditor.UI
             Tables = new UISelectionList<Table>(this.OfType<Table>());
             Partitions = new UISelectionList<Partition>(this.OfType<Partition>());
             Calendars = new UISelectionList<Calendar>(this.OfType<Calendar>());
+            Objects = new UISelectionList<ITabularNamedObject>(this.OfType<ITabularNamedObject>());
         }
 
         private T One<T>() where T: TabularObject
@@ -407,6 +408,18 @@ namespace TabularEditor.UI
         public int DirectCount { get { return _selectedNodes.Count; } }
 
         #region Sub collections
+        [IntelliSense("The currently selected item (if exactly one item is selected in the explorer tree).")]
+        public ITabularNamedObject SelectedItem
+        {
+            get
+            {
+                var obj = this.FirstOrDefault();
+                if (obj == null) throw new Exception("The selection does not contain any objects.");
+                if (this.Skip(1).Any()) throw new Exception("The selection contains more than one object.");
+                return obj;
+            }
+        }
+
         [IntelliSense("The currently selected measure (if exactly one measure is selected in the explorer tree).")]
         public Measure Measure { get { return One<Measure>(); } }
 
@@ -449,6 +462,9 @@ namespace TabularEditor.UI
         [IntelliSense("The currently selected KPI.")]
         public KPI KPI { get { return One<KPI>(); } }
 
+        [IntelliSense("All currently selected KPIs.")]
+        public UISelectionList<KPI> KPIs { get; private set; }
+
         [IntelliSense("The currently selected levels.")]
         public UISelectionList<Level> Levels { get; private set; }
 
@@ -470,8 +486,14 @@ namespace TabularEditor.UI
         [IntelliSense("All currently selected roles.")]
         public UISelectionList<ModelRole> Roles { get; private set; }
 
+        [IntelliSense("The currently selected role (if exactly one role is selected in the explorer tree).")]
+        public ModelRole Role { get { return One<ModelRole>(); } }
+
         [IntelliSense("All currently selected relationships.")]
         public UISelectionList<SingleColumnRelationship> SingleColumnRelationships { get; private set; }
+
+        [IntelliSense("The currently selected relationship (if exactly one relationship is selected in the explorer tree).")]
+        public SingleColumnRelationship SingleColumnRelationship { get { return One<SingleColumnRelationship>(); } }
 
         [IntelliSense("All currently selected perspectives.")]
         public UISelectionList<Perspective> Perspectives { get; private set; }
@@ -490,6 +512,10 @@ namespace TabularEditor.UI
 
         [IntelliSense("All currently selected table permissions.")]
         public UISelectionList<TablePermission> TablePermissions { get; private set; }
+
+        [IntelliSense("The currently selected table permission (if exactly one table permission is selected in the explorer tree).")]
+        public TablePermission TablePermission { get { return One<TablePermission>(); } }
+
         [IntelliSense("The currently selected calculation group (if exactly one calculation group is selected in the explorer tree.)")]
         public CalculationGroupTable CalculationGroup
         {
@@ -511,6 +537,9 @@ namespace TabularEditor.UI
 
         [IntelliSense("All currently selected calculated table columns (including calculated table columns within selected Display Folders).")]
         public UISelectionList<CalculatedTableColumn> CalculatedTableColumns { get; private set; }
+
+        [IntelliSense("The currently selected calculated table column (if exactly one calculated table column is selected in the explorer tree).")]
+        public CalculatedTableColumn CalculatedTableColumn { get { return One<CalculatedTableColumn>(); } }
 
         [IntelliSense("The currently selected data column (if exactly one data column is selected in the explorer tree).")]
         public DataColumn DataColumn { get { return One<DataColumn>(); } }
@@ -566,7 +595,24 @@ namespace TabularEditor.UI
         [IntelliSense("A collection of objects (including folders) that are directly selected in the explorer tree.")]
         public UISelectionList<ITabularNamedObject> Direct { get; private set; }
 
-        internal IEnumerable<Folder> Folders { get; private set; }
+        [IntelliSense("All currently selected objects.")]
+        public UISelectionList<ITabularNamedObject> Objects { get; private set; }
+
+        [IntelliSense("All currently selected display folders in the explorer tree.")]
+        public UISelectionList<Folder> Folders { get; private set; }
+
+        [IntelliSense("The currently selected folder (if exactly one folder is selected in the explorer tree).")]
+        public Folder Folder
+        {
+            get
+            {
+                var folder = Folders.FirstOrDefault();
+                if (folder == null) throw new Exception("The selection does not contain any objects of type Folder");
+                if (Folders.Skip(1).Any()) throw new Exception("The selection contains more than one object of type Folder");
+                return folder;
+            }
+        }
+
         internal IEnumerable<LogicalGroup> Groups { get; private set; }
         #endregion
 


### PR DESCRIPTION
  ## Change description
  Add missing Selected scripting API accessors to TE2

  ### The Problem
  The C# scripting API in Tabular Editor 2 was missing several singular and plural accessor properties on the `Selected`
   object. Users who expected symmetry between singular and plural accessors (e.g., `Selected.Roles` existed but
  `Selected.Role` did not) had no way to safely retrieve a single object of certain types with built-in validation.

  ### How the Issue Occurs
  For several object types, only one direction of access existed: either a plural collection with no singular
  counterpart, or a singular accessor with no plural collection. Additionally, `KPIs`, `Objects`, and `Folders` lacked
  public collection accessors entirely, forcing scripts to use workarounds like LINQ on the base selection instead of
  purpose-built typed collections.

  ### The Fix / Implementation
  Added the missing singular accessors (`Role`, `SingleColumnRelationship`, `TablePermission`, `CalculatedTableColumn`,
  `Folder`, `SelectedItem`) and plural collections (`KPIs`, `Objects`, `Folders`) to the `UITreeSelection` class,
  following the existing established pattern. The `Folders` collection was promoted from an internal implementation
  detail to a public scripting API surface. The collection initialization was refactored to pass folders explicitly into
   the assignment method, matching the approach taken in TE3.

  ### User Impact
  **Before:**
  - No `Selected.Role` — users had to use `Selected.Roles.First()` with no validation
  - No `Selected.SingleColumnRelationship` singular accessor
  - No `Selected.TablePermission` singular accessor
  - No `Selected.CalculatedTableColumn` singular accessor
  - No `Selected.Folder` singular accessor
  - No `Selected.Folders` public collection
  - No `Selected.KPIs` plural collection
  - No `Selected.Objects` generic plural collection
  - No `Selected.SelectedItem` for any single selected object

  **After:**
  - Full singular/plural symmetry for all major object types
  - Scripts throw a descriptive exception if zero or multiple objects are selected when using a singular accessor

  ### Testing
  Existing scripting tests cover the base patterns. The singular accessor pattern is identical to already-tested
  accessors such as `Selected.Measure` and `Selected.Table`.

  ## Type of change
  - [ ] Bug fix
  - [x] New feature (non-breaking addition to scripting API)
  - [ ] Breaking change
  - [ ] Documentation update

  ## Files Changed
  **Modified:** `TabularEditor/UI/UITreeSelection.cs` — added missing Selected accessors and promoted Folders to public
  API

  ## Testing
  **Manual:** Open TE2, load a model, open the C# script editor, verify IntelliSense surfaces the new properties and
  that singular accessors throw when selection count is not exactly one.